### PR TITLE
Remove image from config

### DIFF
--- a/ispy_agent_dvr/config.yaml
+++ b/ispy_agent_dvr/config.yaml
@@ -22,7 +22,6 @@ ports:
   50008/udp: 50008
   50009/udp: 50009
   50010/udp: 50010
-image: rpimeekle/ispy_agent_dvr
 init: false
 webui: http://[HOST]:[PORT:8090]
 watchdog: http://[HOST]:[PORT:8090]


### PR DESCRIPTION
This will force every HA Instance to build the image locally but as the image is not availabel on dockerhub this is neede. BTW: Works fine for me !